### PR TITLE
feat: Add option to use HTML comments instead of details/summary

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,10 +45,18 @@ runs:
         git checkout main
 
         echo "Remove 'open' from any <details> tags"
-        sed -i.tmp -r 's/<details id=([0-9]+) open>/<details id=\1>/g' README.md
+        sed -i.tmp -r 's/<details id=([0-9X]+) open>/<details id=\1>/g' README.md
 
         echo "Add 'open' to step TO_STEP"
         sed -i.tmp -r "s/<details id=$TO_STEP>/<details id=$TO_STEP open>/g" README.md
+
+        echo "Update all HTML comments to hide everything"
+        sed -i.tmp -r 's/<!--step([0-9X]+)-->/<!--step\1/g' README.md
+        sed -i.tmp -r 's/<!--endstep([0-9X]+)-->/endstep\1-->/g' README.md
+
+        echo "Show the current TO_STEP"
+        sed -i.tmp -r "s/<\!--step$TO_STEP/<\!--step$TO_STEP-->/g" README.md
+        sed -i.tmp -r "s/endstep$TO_STEP-->/<\!--endstep$TO_STEP-->/g" README.md
 
         echo "Update the STEP file to TO_STEP"
         echo "$TO_STEP" > .github/script/STEP


### PR DESCRIPTION
### Why:

Towards https://github.com/github/skills/issues/40

### What's being changed:

Currently step authoring looks like this:

```md
<details id=0 open>
  <summary>Start</summary>
</details>

<details id=1>
  <summary>Step 1</summary>
</details>

<details id=2>
  <summary>Step 2</summary>
</details>

<details id=X>
  <summary>Finish</summary>
</details>
```

This would create the option to also author steps like:

```md
<!--step0-->
Start
<!--endstep0-->

<!--step1
Step 1
endstep1-->

<!--step2
Step 2
endstep2-->

<!--stepX
Finish
endstepX-->
```

The purpose of this change would be to hide the step content when starting a course. I tried to think of the easiest way to do this without confusing course authors or creating a big change to how the actions workflows work. For learners this means they would only see the current step they are on. For authors, this means you'd need to play with the HTML comments a bit to see what you are currently working on.
