### PR TITLE
feat: configurable base branch name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   branch_name:
     description: "If the learner is working in a branch, add the branch name."
   base_branch_name:
-    description: "Option name of the base branch (default: main)."
+    description: "Optional name of the base branch (default: main)."
     required: false
     default: "main"
 runs:

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     required: true
   branch_name:
     description: "If the learner is working in a branch, add the branch name."
+  base_branch_name:
+    description: "Option name of the base branch (default: main)."
+    required: false
+    default: "main"
 runs:
   using: composite
   steps:
@@ -41,8 +45,8 @@ runs:
           exit 0
         fi
 
-        echo "Make sure we are on the main branch"
-        git checkout main
+        echo "Make sure we are on the base branch ($BASE_BRANCH_NAME)"
+        git checkout $BASE_BRANCH_NAME
 
         echo "Remove 'open' from any <details> tags"
         sed -i.tmp -r 's/<details id=([0-9X]+) open>/<details id=\1>/g' README.md
@@ -61,7 +65,7 @@ runs:
         echo "Update the STEP file to TO_STEP"
         echo "$TO_STEP" > .github/script/STEP
 
-        echo "Commit the files, and push to main"
+        echo "Commit the files, and push to base branch"
         git config user.name github-actions
         git config user.email github-actions@github.com
         git add README.md
@@ -73,7 +77,7 @@ runs:
         if git show-ref --quiet refs/heads/$BRANCH_NAME
         then
           git checkout $BRANCH_NAME
-          git cherry-pick main
+          git cherry-pick $BASE_BRANCH_NAME
           git push
         else
           echo "Branch $BRANCH_NAME does not exist"


### PR DESCRIPTION
Accepts a new input, `base_branch_name`, to indicate the name of
the branch containing the README file to be updated. Default
`main`.

### Why:

Closes https://github.com/skills/action-update-step/issues/4

### What's being changed:

```yml
  base_branch_name:
    description: "Option name of the base branch (default: main)."
    required: false
    default: "main"
```

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
