### PR TITLE
feat: Use square brackets (filename wildcards)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
         git checkout $BASE_BRANCH_NAME
 
         echo "Update the step to TO_STEP"
-        NEXT_STEP=$(cat .github/steps/$TO_STEP-*.md)
+        NEXT_STEP=$(cat .github/steps/[$TO_STEP]-*.md)
         HEADER=$(awk '/<header>/,/<\/header>/' README.md)
         FOOTER=$(awk '/<footer>/,/<\/footer>/' README.md)
         echo -e "$HEADER\n\n$NEXT_STEP\n\n$FOOTER" > README.md


### PR DESCRIPTION
[$TO_STEP]

### Summary

The course maintainers might like to show multiple steps.
See: skills/publish-packages#25 "TODO UPDATE NEEDED" in 3-merge-your-pull-request.yml
https://github.com/skills/publish-packages/pull/25#discussion_r1220872779
I will open a PR for this: PR skills/publish-packages#26

### Changes

I use square brackets, one of the UNIX filename wildcards, in cat command, so that the indicated steps can be concatenated.
$TO_STEP &rarr; [$TO_STEP]

#### Usage
```yml
- name: Update to Step 45X
  uses: skills/action-update-step@v2
  with:
    token: ${{ secrets.GITHUB_TOKEN }}
    from_step: 3
    to_step: 45X
    branch_name: cd
```

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
