### PR TITLE
fix: git checkout before checking Step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,15 +44,15 @@ runs:
           exit 1
         fi
 
+        echo "Make sure we are on the base branch ($BASE_BRANCH_NAME)"
+        git checkout $BASE_BRANCH_NAME
+
         echo "Check that we are on FROM_STEP"
         if [ "$(cat .github/steps/-step.txt)" != $FROM_STEP ]
         then
           echo "Current step is not $FROM_STEP"
           exit 0
         fi
-
-        echo "Make sure we are on the base branch ($BASE_BRANCH_NAME)"
-        git checkout $BASE_BRANCH_NAME
 
         echo "Update the step to TO_STEP"
         NEXT_STEP=$(cat .github/steps/[$TO_STEP]-*.md)


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->
The if statement checking that we are on FROM_STEP should be run after the `git checkout $BASE_BRANCH_NAME` command.

### Changes
<!-- Describe the changes this pull request introduces. -->
Swap the order

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: #21

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
